### PR TITLE
INFRA-15238 don't collect excluded metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func filterExcludedZones(all []cloudflare.Zone, exclude []string) []cloudflare.Z
 	return filtered
 }
 
-func fetchMetrics() {
+func fetchMetrics(deniedMetricsSet MetricsSet) {
 	var wg sync.WaitGroup
 	zones := fetchZones()
 	accounts := fetchAccounts()
@@ -121,9 +121,9 @@ func fetchMetrics() {
 		targetZones := filteredZones[:sliceLength]
 		filteredZones = filteredZones[len(targetZones):]
 
-		go fetchZoneAnalytics(targetZones, &wg)
-		go fetchZoneColocationAnalytics(targetZones, &wg)
-		go fetchLoadBalancerAnalytics(targetZones, &wg)
+		go fetchZoneAnalytics(targetZones, &wg, deniedMetricsSet)
+		go fetchZoneColocationAnalytics(targetZones, &wg, deniedMetricsSet)
+		go fetchLoadBalancerAnalytics(targetZones, &wg, deniedMetricsSet)
 	}
 
 	wg.Wait()
@@ -165,7 +165,7 @@ func main() {
 
 	go func() {
 		for ; true; <-time.NewTicker(60 * time.Second).C {
-			go fetchMetrics()
+			go fetchMetrics(deniedMetricsSet)
 		}
 	}()
 


### PR DESCRIPTION
## What?

Don't collect metrics that are in the deny list

## Why?

Uses a lot of memory

## Proof

Builds
```
❯ make
CGO_ENABLED=0 go build -o cloudflare_exporter .

❯ file ./cloudflare_exporter 
./cloudflare_exporter: Mach-O 64-bit executable x86_64
```

Runs
```
❯ ./cloudflare_exporter -cf_api_token="$(echo -n $CF_API_TOKEN | base64 --decode)" -listen=":9257" -cf_zones="$CF_ZONE_ID" -metrics_denylist="cloudflare_worker_cpu_time,cloudflare_worker_duration,cloudflare_worker_errors_count,cloudflare_worker_requests_count,cloudflare_zone_bandwidth_cached,cloudflare_zone_bandwidth_content_type,cloudflare_zone_bandwidth_country,cloudflare_zone_bandwidth_ssl_encrypted,cloudflare_zone_bandwidth_total,cloudflare_zone_colocation_edge_response_bytes,cloudflare_zone_colocation_visits,cloudflare_zone_colocation_requests_total,cloudflare_zone_pageviews_total,cloudflare_zone_requests_cached,cloudflare_zone_requests_content_type,cloudflare_zone_requests_country,cloudflare_zone_requests_origin_status_country_host,cloudflare_zone_requests_ssl_encrypted,cloudflare_zone_requests_status_country_host,cloudflare_zone_requests_browser_map_page_views_count,cloudflare_zone_threats_country,cloudflare_zone_threats_total,cloudflare_zone_uniques_total,cloudflare_zone_pool_health_status,cloudflare_zone_pool_requests_total,cloudflare_zone_firewall_events_count,cloudflare_zone_threats_type"
INFO[2023-10-25 12:44:23] Beginning to serve on port:9257, metrics path /metrics 
INFO[2023-10-25 12:44:23] Filtering zone: redaced_zone_id mybigcommerce.com 
```

Metrics
```
curl -s localhost:9257
# HELP cloudflare_zone_requests_status Number of request for zone per HTTP status
# TYPE cloudflare_zone_requests_status counter
cloudflare_zone_requests_status{status="200",zone="mybigcommerce.com"} 499357
cloudflare_zone_requests_status{status="201",zone="mybigcommerce.com"} 359
cloudflare_zone_requests_status{status="202",zone="mybigcommerce.com"} 6
cloudflare_zone_requests_status{status="204",zone="mybigcommerce.com"} 5855
cloudflare_zone_requests_status{status="206",zone="mybigcommerce.com"} 1077
cloudflare_zone_requests_status{status="207",zone="mybigcommerce.com"} 1004
cloudflare_zone_requests_status{status="301",zone="mybigcommerce.com"} 40059
cloudflare_zone_requests_status{status="302",zone="mybigcommerce.com"} 4149
cloudflare_zone_requests_status{status="303",zone="mybigcommerce.com"} 940
cloudflare_zone_requests_status{status="304",zone="mybigcommerce.com"} 50408
cloudflare_zone_requests_status{status="307",zone="mybigcommerce.com"} 115
cloudflare_zone_requests_status{status="308",zone="mybigcommerce.com"} 7
cloudflare_zone_requests_status{status="400",zone="mybigcommerce.com"} 1446
cloudflare_zone_requests_status{status="401",zone="mybigcommerce.com"} 2442
cloudflare_zone_requests_status{status="403",zone="mybigcommerce.com"} 12800
cloudflare_zone_requests_status{status="404",zone="mybigcommerce.com"} 45177
cloudflare_zone_requests_status{status="406",zone="mybigcommerce.com"} 38
cloudflare_zone_requests_status{status="408",zone="mybigcommerce.com"} 4
cloudflare_zone_requests_status{status="409",zone="mybigcommerce.com"} 71
cloudflare_zone_requests_status{status="414",zone="mybigcommerce.com"} 10
cloudflare_zone_requests_status{status="416",zone="mybigcommerce.com"} 3
cloudflare_zone_requests_status{status="422",zone="mybigcommerce.com"} 11
cloudflare_zone_requests_status{status="423",zone="mybigcommerce.com"} 1822
cloudflare_zone_requests_status{status="429",zone="mybigcommerce.com"} 3139
cloudflare_zone_requests_status{status="499",zone="mybigcommerce.com"} 3255
cloudflare_zone_requests_status{status="500",zone="mybigcommerce.com"} 61
cloudflare_zone_requests_status{status="503",zone="mybigcommerce.com"} 960
cloudflare_zone_requests_status{status="520",zone="mybigcommerce.com"} 19
# HELP cloudflare_zone_requests_total Number of requests for zone
# TYPE cloudflare_zone_requests_total counter
cloudflare_zone_requests_total{zone="mybigcommerce.com"} 674594
# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 3.6498e-05
go_gc_duration_seconds{quantile="0.25"} 4.8672e-05
go_gc_duration_seconds{quantile="0.5"} 5.5689e-05
go_gc_duration_seconds{quantile="0.75"} 6.0781e-05
go_gc_duration_seconds{quantile="1"} 0.00015361
go_gc_duration_seconds_sum 0.001362902
go_gc_duration_seconds_count 22
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
go_goroutines 8
# HELP go_info Information about the Go environment.
# TYPE go_info gauge
go_info{version="go1.20.4"} 1
# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
# TYPE go_memstats_alloc_bytes gauge
go_memstats_alloc_bytes 9.54996e+06
# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
# TYPE go_memstats_alloc_bytes_total counter
go_memstats_alloc_bytes_total 1.05666728e+08
# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
# TYPE go_memstats_buck_hash_sys_bytes gauge
go_memstats_buck_hash_sys_bytes 4213
# HELP go_memstats_frees_total Total number of frees.
# TYPE go_memstats_frees_total counter
go_memstats_frees_total 315646
# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
# TYPE go_memstats_gc_sys_bytes gauge
go_memstats_gc_sys_bytes 8.104128e+06
# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
# TYPE go_memstats_heap_alloc_bytes gauge
go_memstats_heap_alloc_bytes 9.54996e+06
# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
# TYPE go_memstats_heap_idle_bytes gauge
go_memstats_heap_idle_bytes 2.146304e+07
# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
# TYPE go_memstats_heap_inuse_bytes gauge
go_memstats_heap_inuse_bytes 1.1370496e+07
# HELP go_memstats_heap_objects Number of allocated objects.
# TYPE go_memstats_heap_objects gauge
go_memstats_heap_objects 32711
# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
# TYPE go_memstats_heap_released_bytes gauge
go_memstats_heap_released_bytes 1.8579456e+07
# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
# TYPE go_memstats_heap_sys_bytes gauge
go_memstats_heap_sys_bytes 3.2833536e+07
# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
# TYPE go_memstats_last_gc_time_seconds gauge
go_memstats_last_gc_time_seconds 1.698263067420521e+09
# HELP go_memstats_lookups_total Total number of pointer lookups.
# TYPE go_memstats_lookups_total counter
go_memstats_lookups_total 0
# HELP go_memstats_mallocs_total Total number of mallocs.
# TYPE go_memstats_mallocs_total counter
go_memstats_mallocs_total 348357
# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
# TYPE go_memstats_mcache_inuse_bytes gauge
go_memstats_mcache_inuse_bytes 14400
# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
# TYPE go_memstats_mcache_sys_bytes gauge
go_memstats_mcache_sys_bytes 15600
# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
# TYPE go_memstats_mspan_inuse_bytes gauge
go_memstats_mspan_inuse_bytes 154560
# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
# TYPE go_memstats_mspan_sys_bytes gauge
go_memstats_mspan_sys_bytes 293760
# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
# TYPE go_memstats_next_gc_bytes gauge
go_memstats_next_gc_bytes 1.220912e+07
# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
# TYPE go_memstats_other_sys_bytes gauge
go_memstats_other_sys_bytes 1.804907e+06
# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
# TYPE go_memstats_stack_inuse_bytes gauge
go_memstats_stack_inuse_bytes 720896
# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
# TYPE go_memstats_stack_sys_bytes gauge
go_memstats_stack_sys_bytes 720896
# HELP go_memstats_sys_bytes Number of bytes obtained from system.
# TYPE go_memstats_sys_bytes gauge
go_memstats_sys_bytes 4.377704e+07
# HELP go_threads Number of OS threads created.
# TYPE go_threads gauge
go_threads 14
# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
# TYPE promhttp_metric_handler_requests_in_flight gauge
promhttp_metric_handler_requests_in_flight 1
# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
# TYPE promhttp_metric_handler_requests_total counter
promhttp_metric_handler_requests_total{code="200"} 2
promhttp_metric_handler_requests_total{code="500"} 0
promhttp_metric_handler_requests_total{code="503"} 0
```

Memory usage:
![Screenshot 2023-10-25 at 12 51 08](https://github.com/bigcommerce/cloudflare-exporter-fork/assets/13359449/4b8645ce-14cd-41f7-bdca-ea254ff93893)
