### PR TITLE
INFRA-21482: Add CF DNS Firewall metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/namsral/flag"
-	"github.com/nelkinda/health-go"
+	health "github.com/nelkinda/health-go"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 )
@@ -106,8 +106,9 @@ func fetchMetrics(deniedMetricsSet MetricsSet) {
 	accounts := fetchAccounts()
 	filteredZones := filterExcludedZones(filterZones(zones, getTargetZones()), getExcludedZones())
 
-	for _, a := range accounts {
-		go fetchWorkerAnalytics(a, &wg)
+	for _, account := range accounts {
+		go fetchWorkerAnalytics(account, &wg)
+		go fetchDnsFirewallAnalytics(account, &wg, deniedMetricsSet)
 	}
 
 	// Make requests in groups of cfgBatchSize to avoid rate limit


### PR DESCRIPTION
## What?
Adds the CF DNS Firewall analytics to the cloudflare-exporter-fork so we can verify that the CF DNS Firewall rollout is working

## Proof

```bash
jason.gellatly ~/work/cloudflare-exporter-fork (infra_21584)$ curl localhost:9257/metrics | grep -i fire
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 15452    0 15452    0     0  12.9M      0 --:--:-- --:--:-- --:--:-- 14.7M
# HELP cloudflare_dns_firewall_query_count DNS Firewall query count by query type and response code
# TYPE cloudflare_dns_firewall_query_count gauge
cloudflare_dns_firewall_query_count{account_id="<snip>",account_name="<snip>",dns_firewall_id="<snip>",query_type="A",response_code="NOERROR"} 4
cloudflare_dns_firewall_query_count{account_id="<snip>",account_name="<snip>",dns_firewall_id="<snip>",query_type="A",response_code="REFUSED"} 28
cloudflare_dns_firewall_query_count{account_id="<snip>",account_name="<snip>",dns_firewall_id="<snip>",query_type="AAAA",response_code="REFUSED"} 20
cloudflare_dns_firewall_query_count{account_id="<snip>",account_name="<snip>",dns_firewall_id="<snip>",query_type="ANY",response_code="NOERROR"} 859
cloudflare_dns_firewall_query_count{account_id="<snip>",account_name="<snip>",dns_firewall_id="<snip>",query_type="DNSKEY",response_code="REFUSED"} 15
cloudflare_dns_firewall_query_count{account_id="<snip>",account_name="<snip>",dns_firewall_id="<snip>",query_type="TXT",response_code="NOERROR"} 286231
cloudflare_dns_firewall_query_count{account_id="<snip>",account_name="<snip>",dns_firewall_id="<snip>",query_type="TXT",response_code="REFUSED"} 6
```