### PR TITLE
Add 5-minute HTTP request stats grouped by origin IP

### DIFF
--- a/cloudflare.go
+++ b/cloudflare.go
@@ -500,7 +500,7 @@ query ($zoneIDs: [String!], $mintime: Time!, $maxtime: Time!, $limit: Int!) {
   viewer {
     zones(filter: { zoneTag_in: $zoneIDs }) {
 	 zoneTag
-     httpRequestsAdaptiveGroups(filter:{datetime_gt: mintime, datetime_lt: $maxtime}, limit: $limit) {
+     httpRequestsAdaptiveGroups(filter:{datetime_gt: $mintime, datetime_lt: $maxtime}, limit: $limit) {
     	dimensions {
         	originIP
       	}

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -500,7 +500,7 @@ query ($zoneIDs: [String!], $mintime: Time!, $maxtime: Time!, $limit: Int!) {
   viewer {
     zones(filter: { zoneTag_in: $zoneIDs }) {
 	 zoneTag
-     httpRequestsAdaptiveGroups(filter:{datetime_gt: $start, datetime_lt: $end}, limit: $limit) {
+     httpRequestsAdaptiveGroups(filter:{datetime_gt: mintime, datetime_lt: $maxtime}, limit: $limit) {
     	dimensions {
         	originIP
       	}

--- a/main.go
+++ b/main.go
@@ -128,6 +128,7 @@ func fetchMetrics(deniedMetricsSet MetricsSet) {
 	zoneCount := len(filteredZones)
 	if zoneCount > 0 && zoneCount <= cfgraphqlreqlimit {
 		go fetchZoneAnalytics(filteredZones, &wg, deniedMetricsSet)
+		go fetchZoneAdaptiveHTTPStats(filteredZones, &wg, deniedMetricsSet)
 		go fetchZoneColocationAnalytics(filteredZones, &wg, deniedMetricsSet)
 		go fetchLoadBalancerAnalytics(filteredZones, &wg, deniedMetricsSet)
 		go fetchLogpushAnalyticsForZone(filteredZones, &wg, deniedMetricsSet)
@@ -138,6 +139,7 @@ func fetchMetrics(deniedMetricsSet MetricsSet) {
 				e = zoneCount
 			}
 			go fetchZoneAnalytics(filteredZones[s:e], &wg, deniedMetricsSet)
+			go fetchZoneAdaptiveHTTPStats(filteredZones[s:e], &wg, deniedMetricsSet)
 			go fetchZoneColocationAnalytics(filteredZones[s:e], &wg, deniedMetricsSet)
 			go fetchLoadBalancerAnalytics(filteredZones[s:e], &wg, deniedMetricsSet)
 			go fetchLogpushAnalyticsForZone(filteredZones[s:e], &wg, deniedMetricsSet)


### PR DESCRIPTION
## Pull Request Template

### Description

Add new metrics for http requests to track performance of different origins (for example; different load balancers fronting the same app servers).

Adds:
* Ratio of 4xx responses to total requests
* Ratio of 5xx responses to total requests
* p50, p95, and p99 quantiles of EdgeTimeToFirstByte

These metrics use the AdaptiveHTTPGroup endpoint to get statistically significant sampled values and return values for a five-minute rolling period to avoid spikes caused by outliers that settle as all samples are aggregated in the Cloudflare metric pipeline.
 
### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

### Testing
- [x] I have run `make pr-tests` and all tests pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

### Code Quality
- [x] My code follows the style guidelines of this project
- [ x I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

### Before Submitting
Please ensure you have completed the following before submitting your PR:

```bash
# Run comprehensive tests
make pr-tests
```

If the above command fails, please fix the issues before submitting your PR.

### Additional Notes
Add any other context about the pull request here.
