### PR TITLE
SD-11577: add support for kv metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Required authentication scopes:
 - `Zone/Firewall Services:Read` is required to fetch zone rule name for `cloudflare_zone_firewall_events_count` metric
 - `Account/Account Rulesets:Read` is required to fetch account rule name for `cloudflare_zone_firewall_events_count` metric
 - `Account:Load Balancing: Monitors and Pools:Read` is required to fetch pools origin health status `cloudflare_pool_origin_health_status` metric
-- `Account/Workers KV Storage:Read` is required for KV metrics
 - `Cloudflare Tunnel Read` is required to fetch Cloudflare Tunnel (Cloudflare Zero Trust) metrics
 
 To authenticate this way, only set `CF_API_TOKEN` (omit `CF_API_EMAIL` and `CF_API_KEY`)
@@ -67,6 +66,7 @@ The exporter can be configured using env variables or command flags.
 | `SCRAPE_DELAY` | scrape delay in seconds, default `300` |
 | `SCRAPE_INTERVAL` | scrape interval in seconds (will query cloudflare every SCRAPE_INTERVAL seconds), default `60` |
 | `METRICS_DENYLIST` | (Optional) cloudflare-exporter metrics to not export, comma delimited list of cloudflare-exporter metrics. If not set, all metrics are exported |
+| `KV_NAMESPACE_IDS` | (Optional) KV namespace IDs to track individually, comma delimited. Unlisted namespaces are aggregated as `other` |
 | `ENABLE_PPROF` | (Optional) enable pprof profiling endpoints at `/debug/pprof/`. Accepts `true` or `false`, default `false`. **Warning**: Only enable in development/debugging environments |
 | `ZONE_<NAME>` |  `DEPRECATED since 0.0.5` (optional) Zone ID. Add zones you want to scrape by adding env vars in this format. You can find the zone ids in Cloudflare dashboards. |
 | `LOG_LEVEL` | Set loglevel. Options are error, warn, info, debug. default `error` |
@@ -85,6 +85,7 @@ Corresponding flags:
   -metrics_path="/metrics": path for metrics, default /metrics
   -scrape_delay=300: scrape delay in seconds, defaults to 300
   -scrape_interval=60: scrape interval in seconds, defaults to 60
+  -kv_namespace_ids="": KV namespace IDs to track individually, comma delimited
   -metrics_denylist="": cloudflare-exporter metrics to not export, comma delimited list
   -enable_pprof=false: enable pprof profiling endpoints at /debug/pprof/
   -log_level="error": log level(error,warn,info,debug)

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Required authentication scopes:
 - `Zone/Firewall Services:Read` is required to fetch zone rule name for `cloudflare_zone_firewall_events_count` metric
 - `Account/Account Rulesets:Read` is required to fetch account rule name for `cloudflare_zone_firewall_events_count` metric
 - `Account:Load Balancing: Monitors and Pools:Read` is required to fetch pools origin health status `cloudflare_pool_origin_health_status` metric
+- `Account/Workers KV Storage:Read` is required for KV metrics
 - `Cloudflare Tunnel Read` is required to fetch Cloudflare Tunnel (Cloudflare Zero Trust) metrics
 
 To authenticate this way, only set `CF_API_TOKEN` (omit `CF_API_EMAIL` and `CF_API_KEY`)
@@ -127,6 +128,8 @@ Note: `ZONE_<name>` configuration is not supported as flag.
 # HELP cloudflare_r2_operation_count Number of operations performed by R2
 # HELP cloudflare_r2_storage_bytes Storage used by R2
 # HELP cloudflare_r2_storage_total_bytes Total storage used by R2
+# HELP cloudflare_kv_requests_count Number of KV operations by namespace and action type
+# HELP cloudflare_kv_latency KV operation latency quantiles (milliseconds)
 ```
 
 ## Helm chart repository

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -7,7 +7,6 @@ import (
 
 	cf "github.com/cloudflare/cloudflare-go/v4"
 	cfaccounts "github.com/cloudflare/cloudflare-go/v4/accounts"
-	cfkv "github.com/cloudflare/cloudflare-go/v4/kv"
 	cfload_balancers "github.com/cloudflare/cloudflare-go/v4/load_balancers"
 	cfpagination "github.com/cloudflare/cloudflare-go/v4/packages/pagination"
 	cfrulesets "github.com/cloudflare/cloudflare-go/v4/rulesets"
@@ -1108,35 +1107,6 @@ func filterNonFreePlanZones(zones []cfzones.Zone) (filteredZones []cfzones.Zone)
 		}
 	}
 	return
-}
-
-func fetchKVNamespaces(accountID string) (map[string]string, error) {
-	namespaceMap := make(map[string]string)
-	ctx, cancel := context.WithTimeout(context.Background(), cftimeout)
-	defer cancel()
-	page := cfclient.KV.Namespaces.ListAutoPaging(ctx, cfkv.NamespaceListParams{
-		AccountID: cf.F(accountID),
-	})
-	if page.Err() != nil {
-		return nil, page.Err()
-	}
-
-	seenIDs := make(map[string]struct{})
-	for page.Next() {
-		if page.Err() != nil {
-			log.Errorf("error during paging KV namespaces: %v", page.Err())
-			break
-		}
-		ns := page.Current()
-		if _, exists := seenIDs[ns.ID]; exists {
-			log.Errorf("fetchKVNamespaces: duplicate namespace ID detected (%s), breaking loop", ns.ID)
-			break
-		}
-		seenIDs[ns.ID] = struct{}{}
-		namespaceMap[ns.ID] = ns.Title
-	}
-
-	return namespaceMap, nil
 }
 
 func fetchKVOperations(accountID string) (*cloudflareResponseKV, error) {

--- a/cloudflare.go
+++ b/cloudflare.go
@@ -7,6 +7,7 @@ import (
 
 	cf "github.com/cloudflare/cloudflare-go/v4"
 	cfaccounts "github.com/cloudflare/cloudflare-go/v4/accounts"
+	cfkv "github.com/cloudflare/cloudflare-go/v4/kv"
 	cfload_balancers "github.com/cloudflare/cloudflare-go/v4/load_balancers"
 	cfpagination "github.com/cloudflare/cloudflare-go/v4/packages/pagination"
 	cfrulesets "github.com/cloudflare/cloudflare-go/v4/rulesets"
@@ -297,6 +298,30 @@ type lbResp struct {
 	} `json:"loadBalancingRequestsAdaptive"`
 
 	ZoneTag string `json:"zoneTag"`
+}
+
+type cloudflareResponseKV struct {
+	Viewer struct {
+		Accounts []kvAccountResp `json:"accounts"`
+	} `json:"viewer"`
+}
+
+type kvAccountResp struct {
+	KvOperationsAdaptiveGroups []struct {
+		Dimensions struct {
+			NamespaceID string `json:"namespaceId"`
+			ActionType  string `json:"actionType"`
+		} `json:"dimensions"`
+		Sum struct {
+			Requests uint64 `json:"requests"`
+		} `json:"sum"`
+		Quantiles struct {
+			LatencyMsP50  float32 `json:"latencyMsP50"`
+			LatencyMsP75  float32 `json:"latencyMsP75"`
+			LatencyMsP99  float32 `json:"latencyMsP99"`
+			LatencyMsP999 float32 `json:"latencyMsP999"`
+		} `json:"quantiles"`
+	} `json:"kvOperationsAdaptiveGroups"`
 }
 
 type cloudflareResponseDNSFirewall struct {
@@ -1083,6 +1108,80 @@ func filterNonFreePlanZones(zones []cfzones.Zone) (filteredZones []cfzones.Zone)
 		}
 	}
 	return
+}
+
+func fetchKVNamespaces(accountID string) (map[string]string, error) {
+	namespaceMap := make(map[string]string)
+	ctx, cancel := context.WithTimeout(context.Background(), cftimeout)
+	defer cancel()
+	page := cfclient.KV.Namespaces.ListAutoPaging(ctx, cfkv.NamespaceListParams{
+		AccountID: cf.F(accountID),
+	})
+	if page.Err() != nil {
+		return nil, page.Err()
+	}
+
+	seenIDs := make(map[string]struct{})
+	for page.Next() {
+		if page.Err() != nil {
+			log.Errorf("error during paging KV namespaces: %v", page.Err())
+			break
+		}
+		ns := page.Current()
+		if _, exists := seenIDs[ns.ID]; exists {
+			log.Errorf("fetchKVNamespaces: duplicate namespace ID detected (%s), breaking loop", ns.ID)
+			break
+		}
+		seenIDs[ns.ID] = struct{}{}
+		namespaceMap[ns.ID] = ns.Title
+	}
+
+	return namespaceMap, nil
+}
+
+func fetchKVOperations(accountID string) (*cloudflareResponseKV, error) {
+	request := graphql.NewRequest(`
+	query ($accountID: String!, $mintime: Time!, $maxtime: Time!, $limit: Int!) {
+		viewer {
+			accounts(filter: {accountTag: $accountID}) {
+				kvOperationsAdaptiveGroups(limit: $limit, filter: {datetime_geq: $mintime, datetime_lt: $maxtime}) {
+					dimensions {
+						namespaceId
+						actionType
+					}
+					sum {
+						requests
+					}
+					quantiles {
+						latencyMsP50
+						latencyMsP75
+						latencyMsP99
+						latencyMsP999
+					}
+				}
+			}
+		}
+	}`)
+
+	now, now1mAgo := GetTimeRange()
+	request.Var("limit", gqlQueryLimit)
+	request.Var("maxtime", now)
+	request.Var("mintime", now1mAgo)
+	request.Var("accountID", accountID)
+
+	gql.Mu.RLock()
+	defer gql.Mu.RUnlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), cftimeout)
+	defer cancel()
+
+	var resp cloudflareResponseKV
+	if err := gql.Client.Run(ctx, request, &resp); err != nil {
+		log.Errorf("error fetching KV operations, err:%v", err)
+		return nil, err
+	}
+
+	return &resp, nil
 }
 
 func fetchDNSFirewallTotals(accountID string) (*cloudflareResponseDNSFirewall, error) {

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func fetchMetrics(deniedMetricsSet MetricsSet) {
 
 	for _, a := range accounts {
 		go fetchWorkerAnalytics(a, &wg)
-		go fetchKVAnalytics(a, &wg)
+		go fetchKVAnalytics(a, &wg, deniedMetricsSet)
 		go fetchLogpushAnalyticsForAccount(a, &wg)
 		go fetchR2StorageForAccount(a, &wg)
 		go fetchLoadblancerPoolsHealth(a, &wg)

--- a/main.go
+++ b/main.go
@@ -110,6 +110,7 @@ func fetchMetrics(deniedMetricsSet MetricsSet) {
 
 	for _, a := range accounts {
 		go fetchWorkerAnalytics(a, &wg)
+		go fetchKVAnalytics(a, &wg)
 		go fetchLogpushAnalyticsForAccount(a, &wg)
 		go fetchR2StorageForAccount(a, &wg)
 		go fetchLoadblancerPoolsHealth(a, &wg)

--- a/main.go
+++ b/main.go
@@ -25,6 +25,10 @@ var (
 	cftimeout time.Duration
 	gql       *GraphQL
 	log       = logrus.New()
+
+	// kvTrackedNamespaces is the set of KV namespace IDs that get their own
+	// namespace_id label. All other namespaces are aggregated under "other".
+	kvTrackedNamespaces map[string]struct{}
 )
 
 // var (
@@ -174,6 +178,18 @@ func runExporter() {
 	log.Debugf("Metrics set: %v", metricsSet)
 	mustRegisterMetrics(metricsSet)
 
+	// Build tracked KV namespace set from config.
+	kvTrackedNamespaces = make(map[string]struct{})
+	if ids := viper.GetString("kv_namespace_ids"); ids != "" {
+		for _, id := range strings.Split(ids, ",") {
+			id = strings.TrimSpace(id)
+			if id != "" {
+				kvTrackedNamespaces[id] = struct{}{}
+			}
+		}
+	}
+	log.Infof("Tracking %d KV namespace IDs", len(kvTrackedNamespaces))
+
 	scrapeInterval := time.Duration(viper.GetInt("scrape_interval")) * time.Second
 	log.Info("Scrape interval set to ", scrapeInterval)
 
@@ -256,6 +272,10 @@ func main() {
 	flags.Duration("cf_timeout", 10*time.Second, "cloudflare request timeout, default 10 seconds")
 	viper.BindEnv("cf_timeout")
 	viper.SetDefault("cf_timeout", 10*time.Second)
+
+	flags.String("kv_namespace_ids", "", "KV namespace IDs to track individually, comma delimited. Unlisted namespaces are aggregated as 'other'")
+	viper.BindEnv("kv_namespace_ids")
+	viper.SetDefault("kv_namespace_ids", "")
 
 	flags.String("metrics_denylist", "", "metrics to not expose, comma delimited list")
 	viper.BindEnv("metrics_denylist")

--- a/prometheus.go
+++ b/prometheus.go
@@ -64,6 +64,8 @@ const (
 	tunnelConnectorInfoMetricName                MetricName = "cloudflare_tunnel_connector_info"
 	tunnelConnectorActiveConnectionsMetricName   MetricName = "cloudflare_tunnel_connector_active_connections"
 	dnsFirewallQueryCountMetricName              MetricName = "cloudflare_dns_firewall_query_count"
+	kvRequestsMetricName                         MetricName = "cloudflare_kv_requests_count"
+	kvLatencyMetricName                          MetricName = "cloudflare_kv_latency"
 )
 
 type MetricsSet map[MetricName]struct{}
@@ -336,6 +338,16 @@ var (
 		Help: "Reports number of active connections for a Cloudflare Tunnel connector",
 	}, []string{"account", "tunnel_id", "client_id"})
 
+	kvRequests = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: kvRequestsMetricName.String(),
+		Help: "Number of KV operations by namespace and action type",
+	}, []string{"namespace_name", "action_type", "account"})
+
+	kvLatency = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: kvLatencyMetricName.String(),
+		Help: "KV operation latency quantiles (milliseconds)",
+	}, []string{"namespace_name", "action_type", "account", "quantile"})
+
 	dnsFirewallQueryCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: dnsFirewallQueryCountMetricName.String(),
 		Help: "DNS Firewall query count by query type and response code",
@@ -388,6 +400,8 @@ func buildAllMetricsSet() MetricsSet {
 	allMetricsSet.Add(tunnelConnectorInfoMetricName)
 	allMetricsSet.Add(tunnelConnectorActiveConnectionsMetricName)
 	allMetricsSet.Add(dnsFirewallQueryCountMetricName)
+	allMetricsSet.Add(kvRequestsMetricName)
+	allMetricsSet.Add(kvLatencyMetricName)
 	return allMetricsSet
 }
 
@@ -537,6 +551,12 @@ func mustRegisterMetrics(deniedMetrics MetricsSet) {
 	if !deniedMetrics.Has(dnsFirewallQueryCountMetricName) {
 		prometheus.MustRegister(dnsFirewallQueryCount)
 	}
+	if !deniedMetrics.Has(kvRequestsMetricName) {
+		prometheus.MustRegister(kvRequests)
+	}
+	if !deniedMetrics.Has(kvLatencyMetricName) {
+		prometheus.MustRegister(kvLatency)
+	}
 }
 
 func fetchLoadblancerPoolsHealth(account cfaccounts.Account, wg *sync.WaitGroup) {
@@ -603,6 +623,40 @@ func fetchWorkerAnalytics(account cfaccounts.Account, wg *sync.WaitGroup) {
 			workerWallTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "status": w.Dimensions.Status, "quantile": "P75"}).Set(float64(w.Quantiles.WallTimeP75))
 			workerWallTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "status": w.Dimensions.Status, "quantile": "P99"}).Set(float64(w.Quantiles.WallTimeP99))
 			workerWallTime.With(prometheus.Labels{"script_name": w.Dimensions.ScriptName, "account": accountName, "status": w.Dimensions.Status, "quantile": "P999"}).Set(float64(w.Quantiles.WallTimeP999))
+		}
+	}
+}
+
+func fetchKVAnalytics(account cfaccounts.Account, wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
+
+	namespaceMap, err := fetchKVNamespaces(account.ID)
+	if err != nil {
+		log.Error("failed to fetch KV namespaces for account ", account.ID, ": ", err)
+		return
+	}
+
+	r, err := fetchKVOperations(account.ID)
+	if err != nil {
+		log.Error("failed to fetch KV operations for account ", account.ID, ": ", err)
+		return
+	}
+
+	accountName := strings.ToLower(strings.ReplaceAll(account.Name, " ", "-"))
+
+	for _, a := range r.Viewer.Accounts {
+		for _, kv := range a.KvOperationsAdaptiveGroups {
+			namespaceName := namespaceMap[kv.Dimensions.NamespaceID]
+			if namespaceName == "" {
+				namespaceName = kv.Dimensions.NamespaceID
+			}
+
+			kvRequests.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName}).Set(float64(kv.Sum.Requests))
+			kvLatency.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P50"}).Set(float64(kv.Quantiles.LatencyMsP50))
+			kvLatency.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P75"}).Set(float64(kv.Quantiles.LatencyMsP75))
+			kvLatency.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P99"}).Set(float64(kv.Quantiles.LatencyMsP99))
+			kvLatency.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P999"}).Set(float64(kv.Quantiles.LatencyMsP999))
 		}
 	}
 }

--- a/prometheus.go
+++ b/prometheus.go
@@ -627,7 +627,7 @@ func fetchWorkerAnalytics(account cfaccounts.Account, wg *sync.WaitGroup) {
 	}
 }
 
-func fetchKVAnalytics(account cfaccounts.Account, wg *sync.WaitGroup) {
+func fetchKVAnalytics(account cfaccounts.Account, wg *sync.WaitGroup, deniedMetricsSet MetricsSet) {
 	wg.Add(1)
 	defer wg.Done()
 
@@ -652,11 +652,15 @@ func fetchKVAnalytics(account cfaccounts.Account, wg *sync.WaitGroup) {
 				namespaceName = kv.Dimensions.NamespaceID
 			}
 
-			kvRequests.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName}).Set(float64(kv.Sum.Requests))
-			kvLatency.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P50"}).Set(float64(kv.Quantiles.LatencyMsP50))
-			kvLatency.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P75"}).Set(float64(kv.Quantiles.LatencyMsP75))
-			kvLatency.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P99"}).Set(float64(kv.Quantiles.LatencyMsP99))
-			kvLatency.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P999"}).Set(float64(kv.Quantiles.LatencyMsP999))
+			if !deniedMetricsSet.Has(kvRequestsMetricName) {
+				kvRequests.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName}).Set(float64(kv.Sum.Requests))
+			}
+			if !deniedMetricsSet.Has(kvLatencyMetricName) {
+				kvLatency.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P50"}).Set(float64(kv.Quantiles.LatencyMsP50))
+				kvLatency.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P75"}).Set(float64(kv.Quantiles.LatencyMsP75))
+				kvLatency.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P99"}).Set(float64(kv.Quantiles.LatencyMsP99))
+				kvLatency.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P999"}).Set(float64(kv.Quantiles.LatencyMsP999))
+			}
 		}
 	}
 }

--- a/prometheus.go
+++ b/prometheus.go
@@ -341,12 +341,12 @@ var (
 	kvRequests = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: kvRequestsMetricName.String(),
 		Help: "Number of KV operations by namespace and action type",
-	}, []string{"namespace_name", "action_type", "account"})
+	}, []string{"namespace_id", "action_type", "account"})
 
 	kvLatency = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: kvLatencyMetricName.String(),
 		Help: "KV operation latency quantiles (milliseconds)",
-	}, []string{"namespace_name", "action_type", "account", "quantile"})
+	}, []string{"namespace_id", "action_type", "account", "quantile"})
 
 	dnsFirewallQueryCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: dnsFirewallQueryCountMetricName.String(),
@@ -631,12 +631,6 @@ func fetchKVAnalytics(account cfaccounts.Account, wg *sync.WaitGroup, deniedMetr
 	wg.Add(1)
 	defer wg.Done()
 
-	namespaceMap, err := fetchKVNamespaces(account.ID)
-	if err != nil {
-		log.Error("failed to fetch KV namespaces for account ", account.ID, ": ", err)
-		return
-	}
-
 	r, err := fetchKVOperations(account.ID)
 	if err != nil {
 		log.Error("failed to fetch KV operations for account ", account.ID, ": ", err)
@@ -647,19 +641,19 @@ func fetchKVAnalytics(account cfaccounts.Account, wg *sync.WaitGroup, deniedMetr
 
 	for _, a := range r.Viewer.Accounts {
 		for _, kv := range a.KvOperationsAdaptiveGroups {
-			namespaceName := namespaceMap[kv.Dimensions.NamespaceID]
-			if namespaceName == "" {
-				namespaceName = kv.Dimensions.NamespaceID
+			nsID := kv.Dimensions.NamespaceID
+			if _, tracked := kvTrackedNamespaces[nsID]; !tracked {
+				nsID = "other"
 			}
 
 			if !deniedMetricsSet.Has(kvRequestsMetricName) {
-				kvRequests.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName}).Set(float64(kv.Sum.Requests))
+				kvRequests.With(prometheus.Labels{"namespace_id": nsID, "action_type": kv.Dimensions.ActionType, "account": accountName}).Add(float64(kv.Sum.Requests))
 			}
 			if !deniedMetricsSet.Has(kvLatencyMetricName) {
-				kvLatency.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P50"}).Set(float64(kv.Quantiles.LatencyMsP50))
-				kvLatency.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P75"}).Set(float64(kv.Quantiles.LatencyMsP75))
-				kvLatency.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P99"}).Set(float64(kv.Quantiles.LatencyMsP99))
-				kvLatency.With(prometheus.Labels{"namespace_name": namespaceName, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P999"}).Set(float64(kv.Quantiles.LatencyMsP999))
+				kvLatency.With(prometheus.Labels{"namespace_id": nsID, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P50"}).Set(float64(kv.Quantiles.LatencyMsP50))
+				kvLatency.With(prometheus.Labels{"namespace_id": nsID, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P75"}).Set(float64(kv.Quantiles.LatencyMsP75))
+				kvLatency.With(prometheus.Labels{"namespace_id": nsID, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P99"}).Set(float64(kv.Quantiles.LatencyMsP99))
+				kvLatency.With(prometheus.Labels{"namespace_id": nsID, "action_type": kv.Dimensions.ActionType, "account": accountName, "quantile": "P999"}).Set(float64(kv.Quantiles.LatencyMsP999))
 			}
 		}
 	}


### PR DESCRIPTION
## Pull Request Template

### Description
Adds Cloudflare KV storage metrics to the Prometheus exporter. Two new metrics are exposed:

- `cloudflare_kv_requests_count` — number of KV operations by namespace and action type (read/write/delete/list)
- `cloudflare_kv_latency` — KV operation latency quantiles (P50/P75/P99/P999) in milliseconds

Namespace IDs are resolved to human-readable names via the Cloudflare REST API (`/storage/kv/namespaces`), falling back to the raw ID if the name cannot be resolved.

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

### Testing

Ran the app locally and verified that `cloudflare_kv_latency` and `cloudflare_kv_requests_count` are visible by visiting `/metrics`

Verified the graphql query gets executed by the app

```
DEBU[2026-03-17 15:47:25] func:main.NewGraphQLClient.func1 file:graphql.go >> query:
        query ($accountID: String!, $mintime: Time!, $maxtime: Time!, $limit: Int!) {
                viewer {
                        accounts(filter: {accountTag: $accountID}) {
                                kvOperationsAdaptiveGroups(limit: $limit, filter: {datetime_geq: $mintime, datetime_lt: $maxtime}) {
                                        dimensions {
                                                namespaceId
                                                actionType
                                        }
                                        sum {
                                                requests
                                        }
                                        quantiles {
                                                latencyMsP50
                                                latencyMsP75
                                                latencyMsP99
                                                latencyMsP999
                                        }
                                }
                        }
                }
        }
```

- [ ] I have run `make pr-tests` and all tests pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

### Code Quality
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

### Before Submitting
Please ensure you have completed the following before submitting your PR:

```bash
# Run comprehensive tests
make pr-tests
```

If the above command fails, please fix the issues before submitting your PR.

### Additional Notes
Add any other context about the pull request here.
