### PR TITLE
Add quantiles for WAE metrics

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -412,8 +412,8 @@ var (
 
 	workerOperationDuration = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: workerOperationDurationMetricName.String(),
-		Help: "Average duration of a worker operation in seconds, sliced by metric_type (worker-defined event type) and label (worker-defined slice)",
-	}, []string{"script_name", "account", "metric_type", "label"})
+		Help: "Worker operation duration quantiles in seconds, sliced by metric_type (worker-defined event type), label (worker-defined slice), and quantile (P50, P75, P99, P999)",
+	}, []string{"script_name", "account", "metric_type", "label", "quantile"})
 )
 
 func buildAllMetricsSet() MetricsSet {
@@ -1407,8 +1407,10 @@ func fetchWorkerWAEAnalytics(account cfaccounts.Account, wg *sync.WaitGroup, den
 			SELECT
 				index1 AS metric_type,
 				blob1 AS label,
-				SUM(_sample_interval * double1) / SUM(_sample_interval) AS avg_duration_ms,
-				SUM(_sample_interval) AS total_requests
+				quantileWeighted(0.50, double1, _sample_interval) AS p50_ms,
+				quantileWeighted(0.75, double1, _sample_interval) AS p75_ms,
+				quantileWeighted(0.99, double1, _sample_interval) AS p99_ms,
+				quantileWeighted(0.999, double1, _sample_interval) AS p999_ms
 			FROM %s
 			WHERE timestamp > NOW() - INTERVAL '5' MINUTE
 			GROUP BY index1, blob1
@@ -1424,20 +1426,33 @@ func fetchWorkerWAEAnalytics(account cfaccounts.Account, wg *sync.WaitGroup, den
 			continue
 		}
 
+		quantiles := []struct {
+			column string
+			label  string
+		}{
+			{"p50_ms", "P50"},
+			{"p75_ms", "P75"},
+			{"p99_ms", "P99"},
+			{"p999_ms", "P999"},
+		}
+
 		for _, row := range resp.Data {
 			metricType, _ := row["metric_type"].(string)
 			label, _ := row["label"].(string)
-			avgDurationMs, _ := row["avg_duration_ms"].(float64)
 			if metricType == "" {
 				continue
 			}
 
-			workerOperationDuration.With(prometheus.Labels{
-				"script_name": scriptName,
-				"account":     accountName,
-				"metric_type": metricType,
-				"label":       label,
-			}).Set(avgDurationMs / 1000.0)
+			for _, q := range quantiles {
+				val, _ := row[q.column].(float64)
+				workerOperationDuration.With(prometheus.Labels{
+					"script_name": scriptName,
+					"account":     accountName,
+					"metric_type": metricType,
+					"label":       label,
+					"quantile":    q.label,
+				}).Set(val / 1000.0)
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Pull Request Template

### Description
Adds quantile breakdown of WAE metrics data

### Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

### Testing
Verified new query runs

```
DEBUG[2026-05-19 13:36:04] func:main.(*WAEClient).Query file:wae.go WAE query (account=acc):
                        SELECT
                                index1 AS metric_type,
                                blob1 AS label,
                                quantileWeighted(0.50, double1, _sample_interval) AS p50_ms,
                                quantileWeighted(0.75, double1, _sample_interval) AS p75_ms,
                                quantileWeighted(0.99, double1, _sample_interval) AS p99_ms,
                                quantileWeighted(0.999, double1, _sample_interval) AS p999_ms
                        FROM data
                        WHERE timestamp > NOW() - INTERVAL '5' MINUTE
                        GROUP BY index1, blob1
                        FORMAT JSON
```

### Code Quality
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

### Before Submitting
Please ensure you have completed the following before submitting your PR:

```bash
# Run comprehensive tests
make pr-tests
```

If the above command fails, please fix the issues before submitting your PR.

### Additional Notes
Add any other context about the pull request here.
